### PR TITLE
add pep8/flake8 to task run list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # TOX Setup
 [tox]
 envlist =
+    pep8
     py27
     py34
     py35


### PR DESCRIPTION
Could you add the pep8 check to the envlist so that it is also always run? That should help keeping the code pep8 compliant.