### PR TITLE
add tests for APK module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[html]
+directory = /tmp/htmlcov
+
 [run]
 omit =
     viper/modules/pymacho_helper/pymacho/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,24 @@
 # This file is part of Viper - https://github.com/viper-framework/viper
 # See the file 'LICENSE' for copying permission.
 
+import pytest
+import tempfile
 import os
+import shutil
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'viper-test-files/test_files',)
+
+
+@pytest.fixture()
+def cleandir():
+    newpath = tempfile.mkdtemp(prefix="viper_tests_tmp_")
+    os.chdir(newpath)
+    yield
+    shutil.rmtree(newpath)
+
+
+@pytest.fixture()
+def cleandir_keep():
+    newpath = tempfile.mkdtemp(prefix="viper_tests_tmp_")
+    os.chdir(newpath)
+    yield

--- a/tests/modules/test_apk.py
+++ b/tests/modules/test_apk.py
@@ -107,7 +107,7 @@ class TestAPK:
 
         assert re.search(r".*argument -d/--dump: expected one argument*", out)
 
-    @pytest.mark.usefixtures("cleandir_keep")
+    @pytest.mark.usefixtures("cleandir")
     @pytest.mark.parametrize("filename", ["hello-world.apk"])
     def test_dump(self, capsys, filename):
         __sessions__.new(os.path.join(FIXTURE_DIR, filename))

--- a/tests/modules/test_apk.py
+++ b/tests/modules/test_apk.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# This file is part of Viper - https://github.com/viper-framework/viper
+# See the file 'LICENSE' for copying permission.
+
+import os
+import re
+
+import pytest
+
+from tests.conftest import FIXTURE_DIR
+
+from viper.modules import apk
+from viper.modules.apk import HAVE_ANDROGUARD
+from viper.common.abstracts import Module
+from viper.common.abstracts import ArgumentErrorCallback
+
+from viper.core.session import __sessions__
+
+
+class TestAPK:
+    def teardown_method(self):
+        __sessions__.close()
+
+    def test_init(self):
+        instance = apk.AndroidPackage()
+        assert isinstance(instance, apk.AndroidPackage)
+        assert isinstance(instance, Module)
+
+    def test_androguard_installed(self):
+        assert HAVE_ANDROGUARD is True
+
+    # def test_androguard_not_installed(self):
+    #     # assert HAVE_ANDROGUARD is True
+    #     HAVE_ANDROGUARD = False
+    #     instance = apk.AndroidPackage()
+    #     assert isinstance(instance, apk.AndroidPackage)
+    #     assert isinstance(instance, Module)
+
+    def test_args_exception(self):
+        instance = apk.AndroidPackage()
+        with pytest.raises(ArgumentErrorCallback) as excinfo:
+            instance.parser.parse_args(["-h"])
+        excinfo.match(r".*Parse Android Applications.*")
+
+    def test_no_session(self, capsys):
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-i"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*No open session*", out)
+        # assert out == ""
+
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_info(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-i"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*Package Name: de.rhab.helloworld*", out)
+
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_perm(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-p"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*APK Permissions*", out)
+
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_file(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-f"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*APK Contents*", out)
+
+    @pytest.mark.parametrize("filename,pkg_name", [("hello-world.apk", "de.rhab.helloworld")])
+    def test_all(self, capsys, filename, pkg_name):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-a"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*Package Name: {}*".format(pkg_name), out)
+
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_dump_no_parameter(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-d"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*argument -d/--dump: expected one argument*", out)
+
+    @pytest.mark.usefixtures("cleandir_keep")
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_dump(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-d hello-world.dump"]
+
+        # TODO(frennkie) this test fails (Can't convert 'bytes' object to str implicitly)
+        # instance.run()
+        # out, err = capsys.readouterr()
+        #
+        # assert 0

--- a/tests/modules/test_apk.py
+++ b/tests/modules/test_apk.py
@@ -115,7 +115,8 @@ class TestAPK:
         instance.command_line = ["-d hello-world.dump"]
 
         # TODO(frennkie) this test fails (Can't convert 'bytes' object to str implicitly)
-        # instance.run()
-        # out, err = capsys.readouterr()
-        #
-        # assert 0
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*Decompiling Code*", out)
+        assert re.search(r".*Decompiled code saved to*", out)

--- a/tests/modules/test_apk.py
+++ b/tests/modules/test_apk.py
@@ -49,7 +49,7 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*No open session*", out)
+        assert re.search(r".*No open session.*", out)
         # assert out == ""
 
     @pytest.mark.parametrize("filename", ["hello-world.apk"])
@@ -72,7 +72,7 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*APK Permissions*", out)
+        assert re.search(r".*APK Permissions.*", out)
 
     @pytest.mark.parametrize("filename", ["hello-world.apk"])
     def test_file(self, capsys, filename):
@@ -83,7 +83,19 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*APK Contents*", out)
+        assert re.search(r".*APK Contents.*", out)
+
+    @pytest.mark.parametrize("filename", ["hello-world.apk"])
+    def test_url(self, capsys, filename):
+        __sessions__.new(os.path.join(FIXTURE_DIR, filename))
+        instance = apk.AndroidPackage()
+        instance.command_line = ["-u"]
+
+        instance.run()
+        out, err = capsys.readouterr()
+
+        assert re.search(r".*http://schemas.android.com/apk/res/android.*", out)
+        assert not re.search(r".*http://foo.example.bar.*", out)
 
     @pytest.mark.parametrize("filename,pkg_name", [("hello-world.apk", "de.rhab.helloworld")])
     def test_all(self, capsys, filename, pkg_name):
@@ -94,7 +106,7 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*Package Name: {}*".format(pkg_name), out)
+        assert re.search(r".*Package Name: {}.*".format(pkg_name), out)
 
     @pytest.mark.parametrize("filename", ["hello-world.apk"])
     def test_dump_no_parameter(self, capsys, filename):
@@ -105,7 +117,7 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*argument -d/--dump: expected one argument*", out)
+        assert re.search(r".*argument -d/--dump: expected one argument.*", out)
 
     @pytest.mark.usefixtures("cleandir")
     @pytest.mark.parametrize("filename", ["hello-world.apk"])
@@ -118,5 +130,5 @@ class TestAPK:
         instance.run()
         out, err = capsys.readouterr()
 
-        assert re.search(r".*Decompiling Code*", out)
-        assert re.search(r".*Decompiled code saved to*", out)
+        assert re.search(r".*Decompiling Code.*", out)
+        assert re.search(r".*Decompiled code saved to.*", out)


### PR DESCRIPTION
Create initial tests for APK module. Sample .apk file is just a simple
hello world app that I wrote. The dump option fails and I assume this is
a Python3 issue. Needs to be checked further.